### PR TITLE
Use docker.io/library/nginx instead of building from source code

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,8 +1,3 @@
-FROM docker.io/library/ubuntu
+FROM docker.io/library/nginx
 ARG port
-RUN apt-get update && apt-get install -y build-essential less wget
-RUN wget https://nginx.org/download/nginx-1.23.1.tar.gz && tar xfz nginx-1.23.1.tar.gz
-RUN cd nginx-1.23.1 && ./configure --prefix=/usr  --without-http_gzip_module --without-http_rewrite_module && make -j 4 && make install
-RUN sed  -i "s/listen\s\+80;/listen ${port};/g" /usr/conf/nginx.conf
-STOPSIGNAL SIGQUIT
-CMD ["nginx", "-g", "daemon off;"]
+RUN sed  -i "s/listen\s\+80;/listen ${port};/g" /etc/nginx/conf.d/default.conf

--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@ This is a demo showing that it is possible to run a socket-activated nginx conta
    ```
 
 > **Note**
-> The _Containerfile_ builds nginx with many features disabled. Hopefully this demo could be modified to instead use an official nginx container image (see https://github.com/eriksjolund/podman-nginx-socket-activation/issues/1).
-
-> **Note**
 > nginx has no official support for systemd socket activation (feature request: https://trac.nginx.org/nginx/ticket/237). This demo makes use of the fact that "_nginx includes an undocumented, internal socket-passing mechanism_" quote from https://freedesktop.org/wiki/Software/systemd/DaemonSocketActivation/
 
 ## Advantages of using rootless Podman with socket activation


### PR DESCRIPTION
The container image docker.io/library/nginx
supports socket activation since the merge of
of the GitHub PR

https://github.com/nginxinc/docker-nginx/pull/703

(There is no support for the systemd environment
variables LISTEN_FDS, LISTEN_FDNAMES, LISTEN_PID
but Nginx supports the undocumented environment variable NGINX)

Fixes: https://github.com/eriksjolund/podman-nginx-socket-activation/issues/1

Signed-off-by: Erik Sjölund <erik.sjolund@gmail.com>