### PR TITLE
Add Example 6: proxy and backend are socket-activated systemd system services with User=

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Overview of the examples
 | [Example 3](examples/example3) | systemd system service (with `User=test3`) | 80 | no | rootless podman | Status: experimental |
 | [Example 4](examples/example4) | systemd system service (with `User=test4`) | 80 | no | rootless podman | Similar to Example 3 but configured to run as an HTTP reverse proxy. Status: experimental. |
 | [Example 5](examples/example5) | systemd system service (with `User=test5`) | 80 | no | rootless podman | Similar to Example 4 but the containers use `--network=none` and communicate over a Unix socket. Status: experimental. |
+| [Example 6](examples/example6) | systemd system service (with `User=test6`) | 80 | no | rootless podman | Similar to Example 5 but the backend web server is
+started with _socket activation_ in a _systemd system service_ with `User=test6`. Status: experimental. |
 
 > **Note**
 > nginx has no official support for systemd socket activation (feature request: https://trac.nginx.org/nginx/ticket/237). These examples makes use of the fact that "_nginx includes an undocumented, internal socket-passing mechanism_" quote from https://freedesktop.org/wiki/Software/systemd/DaemonSocketActivation/

--- a/examples/example6/README.md
+++ b/examples/example6/README.md
@@ -1,0 +1,91 @@
+return to [main page](../..)
+
+# Example 6
+
+status: experimental
+
+``` mermaid
+graph TB
+
+    a1[curl] -.->a2[nginx container reverse proxy]
+    a2 -->|"for http://nginx.example.com"| a4["nginx backend container"]
+```
+
+Containers:
+
+| Container image | Type of service | Role | Network | Socket activation | SELinux |
+| --              | --              | --   | --      | --                | --      |
+| docker.io/library/nginx | systemd system service with `User=test6` | HTTP reverse proxy | `--network=none` | :heavy_check_mark: | disabled |
+| docker.io/library/nginx | systemd system service with `User=test6` | backend web server | `--network=none` | :heavy_check_mark: | enabled |
+
+> [!WARNING]  
+> The container running the proxy is currently configured with`--security-opt label=disable` which means that SELinux is disabled for that container.
+
+This example is similar to [Example 5](../example5) but here the backend web server is
+started with _socket activation_ from a _systemd system service_ with `User=test6`.
+No systemd user services are used.
+All containers are run by rootless podman, which belongs to the user _test_.
+
+## Requirements
+
+These instructions were tested on Fedora 39 with Podman 4.7.2.
+
+## Install instructions
+
+These install instructions will create the new user _test6_ and install these files:
+
+```
+/etc/systemd/system/example6-proxy.socket
+/etc/systemd/system/example6-proxy.service
+/etc/systemd/system/example6-backend.socket
+/etc/systemd/system/example6-backend.service
+
+/home/test6/nginx-reverse-proxy-conf/nginx-example-com.conf
+/home/test6/nginx-reverse-proxy-conf/default.conf
+/run/user/1006/backend-socket
+```
+(Here assuming `1006` is the UID of _test6_).
+The install instructions will also start _example6-proxy.socket_ and _example6-backend.socket_.
+
+1. Clone this GitHub repo
+   ```
+   $ git clone URL
+   ```
+2. Change directory
+   ```
+   $ cd podman-nginx-socket-activation
+   ```
+3. Choose a username that will be created and used for the test
+   ```
+   $ user=test6
+   ```
+4. Run install script
+   ```
+   $ sudo bash ./examples/example6/install.bash ./ $user
+   ```
+5. Check the status of the backend socket
+   ```
+   $ sudo systemctl is-active example6-backend.socket
+   active
+   ```
+6. Check the status of the HTTP reverse proxy socket
+   ```
+   $ sudo systemctl is-active example6-proxy.socket
+   active
+   ```
+
+## Test the nginx reverse proxy
+
+1. Test the nginx HTTP reverse proxy
+   ```
+   $ curl -s --resolve nginx.example.com:80:127.0.0.1 nginx.example.com:80 | head -4
+    <!DOCTYPE html>
+    <html>
+    <head>
+    <title>Welcome to nginx!</title>
+   ```
+   Result: Success. The nginx reverse proxy fetched the output from the nginx backend.
+
+## Discussion about SELinux
+
+To get it to work, `--security-opt label=disable` was given to the _podman run_ command in _example6-proxy.service_.

--- a/examples/example6/example6-backend.service.in
+++ b/examples/example6/example6-backend.service.in
@@ -1,0 +1,34 @@
+# This file should be preprocessed with the envsubst command
+# to convert such text strings: ${envsubst_variablename}
+
+[Unit]
+Wants=network-online.target
+After=network-online.target
+Requires=user@${envsubst_uid}.service
+After=user@${envsubst_uid}.service
+RequiresMountsFor=/run/user/${envsubst_uid}/containers
+
+[Service]
+User=${envsubst_user}
+Environment=PODMAN_SYSTEMD_UNIT=%n
+KillMode=mixed
+ExecStop=/usr/bin/podman rm -f -i --cidfile=/run/user/${envsubst_uid}/%N.cid
+ExecStopPost=-/usr/bin/podman rm -f -i --cidfile=/run/user/${envsubst_uid}/%N.cid
+Delegate=yes
+Type=notify
+NotifyAccess=all
+SyslogIdentifier=%N
+ExecStart=/usr/bin/podman run \
+     --cidfile=/run/user/${envsubst_uid}/%N.cid \
+     --cgroups=split \
+     --rm \
+     --env "NGINX=3;" \
+      -d \
+     --network=none \
+     --replace \
+     --userns keep-id:uid=101,gid=101 \
+     --user 0:0 \
+     --name systemd-%N \
+     --sdnotify=conmon \
+     --volume /home/${envsubst_user}/nginx-backend-conf:/etc/nginx/conf.d:Z \
+     docker.io/library/nginx

--- a/examples/example6/example6-backend.socket.in
+++ b/examples/example6/example6-backend.socket.in
@@ -1,0 +1,10 @@
+[Unit]
+Description=Example 6 backend socket
+
+[Socket]
+ListenStream=/run/user/${envsubst_uid}/backend-socket
+SocketUser=${envsubst_user}
+SocketGroup=${envsubst_user}
+SocketMode=0600
+[Install]
+WantedBy=sockets.target

--- a/examples/example6/example6-proxy.service.in
+++ b/examples/example6/example6-proxy.service.in
@@ -1,0 +1,41 @@
+# This file should be preprocessed with the envsubst command
+# to convert such text strings: ${envsubst_variablename}
+
+[Unit]
+Wants=network-online.target
+After=network-online.target
+Requires=user@${envsubst_uid}.service
+After=user@${envsubst_uid}.service
+
+Requires=example6-backend.socket
+After=example6-backend.socket
+
+RequiresMountsFor=/run/user/${envsubst_uid}/containers
+
+[Service]
+User=${envsubst_user}
+Environment=PODMAN_SYSTEMD_UNIT=%n
+KillMode=mixed
+ExecStop=/usr/bin/podman rm -f -i --cidfile=/run/user/${envsubst_uid}/%N.cid
+ExecStopPost=-/usr/bin/podman rm -f -i --cidfile=/run/user/${envsubst_uid}/%N.cid
+Delegate=yes
+Type=notify
+NotifyAccess=all
+SyslogIdentifier=%N
+ExecStart=/usr/bin/podman run \
+     --cidfile=/run/user/${envsubst_uid}/%N.cid \
+     --cgroups=split \
+     --rm \
+     --env "NGINX=3;" \
+      -d \
+     --network=none \
+     --replace \
+     --userns keep-id:uid=101,gid=101 \
+     --user 0:0 \
+     --name systemd-%N \
+     --sdnotify=conmon \
+     --security-opt label=disable \
+     --volume /home/${envsubst_user}/nginx-reverse-proxy-conf:/etc/nginx/conf.d:Z \
+     --volume /run/user/${envsubst_uid}/backend-socket:/var/socket:Z \
+     docker.io/library/nginx
+

--- a/examples/example6/example6-proxy.socket
+++ b/examples/example6/example6-proxy.socket
@@ -1,0 +1,8 @@
+[Unit]
+Description=Example 6 proxy socket
+
+[Socket]
+ListenStream=0.0.0.0:80
+
+[Install]
+WantedBy=sockets.target

--- a/examples/example6/install.bash
+++ b/examples/example6/install.bash
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+
+repodir=$1
+user=$2
+
+# Alternatively a system account with no shell access could be created:
+# sudo useradd --system --shell /usr/sbin/nologin --create-home --add-subids-for-system -d "/home/$user" -- "$user"
+sudo useradd -- "$user"
+
+sudo mkdir -p /srv/backend-socketdir
+
+#sudo chown  -- "$user:$user" /srv/dir
+
+uid=$(id -u -- "$user")
+
+sourcedir="$repodir/examples/example6"
+
+sudo install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/nginx-reverse-proxy-conf"
+sudo install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/nginx-reverse-proxy-conf" "$sourcedir/nginx-reverse-proxy-conf/nginx-example-com.conf"
+sudo install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/nginx-reverse-proxy-conf" "$sourcedir/nginx-reverse-proxy-conf/default.conf"
+
+sudo install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/nginx-backend-conf"
+sudo install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/nginx-backend-conf" "$sourcedir/nginx-backend-conf/default.conf"
+
+sudo install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/.config/containers/systemd"
+sudo install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/.config/containers/systemd" "$sourcedir/nginx.container"
+sudo install --mode 0644 -Z -D -o root -g root --target-directory /etc/systemd/system/ "$sourcedir/example6-proxy.socket"
+
+# envsubst is used for text replacement
+cat $repodir/examples/example6/example6-proxy.service.in | sudo bash -c "cat - | envsubst_user=$user envsubst_uid=$uid envsubst > /etc/systemd/system/example6-proxy.service"
+cat $repodir/examples/example6/example6-backend.service.in | sudo bash -c "cat - | envsubst_user=$user envsubst_uid=$uid envsubst > /etc/systemd/system/example6-backend.service"
+cat $repodir/examples/example6/example6-backend.socket.in | sudo bash -c "cat - | envsubst_user=$user envsubst_uid=$uid envsubst > /etc/systemd/system/example6-backend.socket"
+cat $repodir/examples/example6/nginx-backend-conf/nginx-example-com.conf.in | sudo bash -c "cat - | envsubst_user=$user envsubst_uid=$uid envsubst > /home/$user/nginx-backend-conf/nginx-example-com.conf"
+
+sudo chown "$user:$user" "/home/$user/nginx-backend-conf/nginx-example-com.conf"
+
+sudo loginctl enable-linger "$user"
+
+sudo systemctl daemon-reload
+
+sudo systemctl start example6-backend.socket
+sudo systemctl start example6-proxy.socket

--- a/examples/example6/nginx-backend-conf/default.conf
+++ b/examples/example6/nginx-backend-conf/default.conf
@@ -1,0 +1,12 @@
+server {
+ listen 80;
+ server_name  localhost;
+ location / {
+     root   /usr/share/nginx/html;
+     index  index.html index.htm;
+ }
+ error_page   500 502 503 504  /50x.html;
+ location = /50x.html {
+     root   /usr/share/nginx/html;
+ }
+}

--- a/examples/example6/nginx-backend-conf/nginx-example-com.conf.in
+++ b/examples/example6/nginx-backend-conf/nginx-example-com.conf.in
@@ -1,0 +1,12 @@
+server {
+  listen unix:/run/user/${envsubst_uid}/backend-socket;
+  server_name nginx.example.com;
+  location / {
+     root   /usr/share/nginx/html;
+     index  index.html index.htm;
+  }
+  error_page   500 502 503 504  /50x.html;
+  location = /50x.html {
+      root   /usr/share/nginx/html;
+  }
+}

--- a/examples/example6/nginx-reverse-proxy-conf/default.conf
+++ b/examples/example6/nginx-reverse-proxy-conf/default.conf
@@ -1,0 +1,12 @@
+server {
+ listen 80;
+ server_name  localhost;
+ location / {
+     root   /usr/share/nginx/html;
+     index  index.html index.htm;
+ }
+ error_page   500 502 503 504  /50x.html;
+ location = /50x.html {
+     root   /usr/share/nginx/html;
+ }
+}

--- a/examples/example6/nginx-reverse-proxy-conf/nginx-example-com.conf
+++ b/examples/example6/nginx-reverse-proxy-conf/nginx-example-com.conf
@@ -1,0 +1,10 @@
+server {
+  listen 80;
+  server_name nginx.example.com;
+  location / {
+    proxy_pass http://nginx/;
+  }
+}
+upstream nginx {
+    server unix:/var/socket;
+}


### PR DESCRIPTION
This example is similar to Example 5 but here the backend web server is started with socket activation from a systemd system service with `User=test6`. No systemd user services are used.
The container running the proxy is currently configured with`--security-opt label=disable` which means that SELinux is disabled for that container.