### PR TITLE
Add Example 7: reverse proxy for two backends (avoiding experimental features)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,15 @@ See also the [Podman socket activation tutorial](https://github.com/containers/p
 
 Overview of the examples
 
-| Example | Type of service | Port | Using quadlet | rootful/rootless podman | Comment |
+| Example | Type of service | Ports | Using quadlet | rootful/rootless podman | Comment |
 | --      | --              |   -- | --      | --   | --  |
-| [Example 1](examples/example1) | systemd user service | 8080 | yes | rootless podman | Only unprivileged port numbers can be used |
-| [Example 2](examples/example2) | systemd system service | 80 | yes | rootful podman | |
-| [Example 3](examples/example3) | systemd system service (with `User=test3`) | 80 | no | rootless podman | Status: experimental |
-| [Example 4](examples/example4) | systemd system service (with `User=test4`) | 80 | no | rootless podman | Similar to Example 3 but configured to run as an HTTP reverse proxy. Status: experimental. |
-| [Example 5](examples/example5) | systemd system service (with `User=test5`) | 80 | no | rootless podman | Similar to Example 4 but the containers use `--network=none` and communicate over a Unix socket. Status: experimental. |
-| [Example 6](examples/example6) | systemd system service (with `User=test6`) | 80 | no | rootless podman | Similar to Example 5 but the backend web server is started with _socket activation_ in a _systemd system service_ with `User=test6`. Status: experimental. |
+| [Example 1](examples/example1) | systemd user service | 8080/TCP | yes | rootless podman | Only unprivileged port numbers can be used |
+| [Example 2](examples/example2) | systemd system service | 80/TCP | yes | rootful podman | |
+| [Example 3](examples/example3) | systemd system service (with `User=test3`) | 80/TCP | no | rootless podman | Status: experimental |
+| [Example 4](examples/example4) | systemd system service (with `User=test4`) | 80/TCP | no | rootless podman | Similar to Example 3 but configured to run as an HTTP reverse proxy. Status: experimental. |
+| [Example 5](examples/example5) | systemd system service (with `User=test5`) | 80/TCP | no | rootless podman | Similar to Example 4 but the containers use `--network=none` and communicate over a Unix socket. Status: experimental. |
+| [Example 6](examples/example6) | systemd system service (with `User=test6`) | 80/TCP | no | rootless podman | Similar to Example 5 but the backend web server is started with _socket activation_ in a _systemd system service_ with `User=test6`. Status: experimental. |
+| [Example 7](examples/example7) | systemd user service | 80/TCP, 443/TCP | yes | rootless podman | HTTP reverse proxy with two backend containers. `ip_unprivileged_port_start` ≤ 80 is required. Status: beta. |
 
 > **Note**
 > nginx has no official support for systemd socket activation (feature request: https://trac.nginx.org/nginx/ticket/237). These examples makes use of the fact that "_nginx includes an undocumented, internal socket-passing mechanism_" quote from https://freedesktop.org/wiki/Software/systemd/DaemonSocketActivation/

--- a/examples/example7/README.md
+++ b/examples/example7/README.md
@@ -1,0 +1,130 @@
+return to [main page](../..)
+
+# Example 7
+
+status: Beta.
+
+Example 7 was written in July 2025. I'll change to status `stable` in a few months unless
+there are github issues with reports of problems.
+
+``` mermaid
+graph TB
+
+    a1[curl] -.->a2[nginx container reverse proxy]
+    a2 -->a3["whoami1 container"]
+    a2 -->a4["whoami2 container"]
+```
+
+Containers:
+
+| Container image | Type of service | Role | Network | Socket activation |
+| --              | --              | --   | --      | --                |
+| docker.io/library/nginx | systemd user service | HTTP reverse proxy | [internal bridge network](example4-net.network) | :heavy_check_mark: |
+| docker.io/traefik/whoami | systemd user service | backend web server | [internal bridge network](example4-net.network) | |
+| docker.io/traefik/whoami | systemd user service | backend web server | [internal bridge network](example4-net.network) | |
+
+This example is similar to [Example 4](../example4) but here the nginx container is configured
+as an HTTP reverse proxy for two backend web server containers (whoami1 and whoami2).
+All containers are run by rootless podman with quadlets.
+A self signed certificate created with `openssl` is used to provide https.
+
+## Requirements
+
+* podman 4.4.0 or later (needed for using [quadlets](https://www.redhat.com/en/blog/quadlet-podman)). Not strictly needed for this example but podman 5.3.0 or later is recommended because then `AddHost=postgres.example.com:host-gateway`, `host.containers.internal` or `host.docker.internal` could be used to let a container on the custom network connect to a service that is listening on the host's main network interface. For details, see [Outbound TCP/UDP connections to the host's main network interface (e.g eth0)](https://github.com/eriksjolund/podman-networking-docs?tab=readme-ov-file#outbound-tcpudp-connections-to-the-hosts-main-network-interface-eg-eth0)
+
+* `ip_unprivileged_port_start` ≤ 80
+
+   Verify that [`ip_unprivileged_port_start`](https://github.com/eriksjolund/podman-networking-docs#configure-ip_unprivileged_port_start) is less than or equal to 80
+   ```
+   $ cat /proc/sys/net/ipv4/ip_unprivileged_port_start
+   80
+   ```
+
+These instructions were tested on Fedora 42 with Podman 5.5.1.
+
+## Install instructions
+
+1. Go to home directory
+   ```
+   cd $HOME
+   ```
+2. Clone this GitHub repo
+   ```
+   $ git clone URL
+   ```
+3. Change directory
+   ```
+   $ cd podman-nginx-socket-activation/examples/example7
+   ```
+4. Run install script
+   ```
+   $ bash ./install.bash
+   ```
+5. Check the status of the backend containers
+   ```
+   $ systemctl --user is-active whoami1.service
+   active
+   $ systemctl --user is-active whoami2.service
+   active
+   ```
+6. Check the status of the nginx socket
+   ```
+   $ systemctl --user is-active nginx.socket
+   active
+   ```
+   
+## Test nginx reverse proxy
+
+1. Test the nginx HTTP reverse proxy by download https://whoami1.example.com
+   ```
+   curl --resolve whoami1.example.com:443:127.0.0.1 --cacert ~/ca.crt https://whoami1.example.com
+   ```
+   The following output is printed
+   ```
+   Hostname: 329327a50b00
+   IP: 127.0.0.1
+   IP: ::1
+   IP: 10.89.0.2
+   IP: fe80::bcf3:7eff:fe98:c52f
+   RemoteAddr: 10.89.0.4:59084
+   GET / HTTP/1.1
+   Host: whoami1.example.com
+   User-Agent: curl/8.11.1
+   Accept: */*
+   Connection: close
+   X-Forwarded-For: ::ffff:127.0.0.1
+   X-Forwarded-Proto: https
+   X-Real-Ip: ::ffff:127.0.0.1
+   ```
+2. Test that HTTP redirect works for the URL http://whoami1.example.com
+   ```
+   curl --resolve whoami1.example.com:80:127.0.0.1 -sD - http://whoami1.example.com -o /dev/null
+   ```
+   The following output is printed
+   ```   
+   HTTP/1.1 301 Moved Permanently
+   Server: nginx/1.29.0
+   Date: Wed, 09 Jul 2025 13:12:12 GMT
+   Content-Type: text/html
+   Content-Length: 169
+   Connection: keep-alive
+   Location: https://whoami1.example.com/
+   ```
+
+## Using `Internal=true`
+
+The containers _whoami1_ and _whoami2_ do not need to create outbound connections to the internet.
+
+To deny access to the internet from the custom network, append append the line
+
+```
+Internal=true
+```
+
+to [example7.network](example7.network).
+
+This improves security. For details, see the blog post
+[_How to limit container privilege with socket activation_](https://www.redhat.com/sysadmin/socket-activation-podman)
+
+Socket activation is not affected by `Internal=true`. In other words, the nginx container get incoming connections
+from the internet even when the custom network is configured with `Internal=true`.

--- a/examples/example7/example7.network
+++ b/examples/example7/example7.network
@@ -1,0 +1,3 @@
+[Network]
+# To give the containers access to the internet, remove the line `Internal=true`
+Internal=true

--- a/examples/example7/install.bash
+++ b/examples/example7/install.bash
@@ -1,0 +1,34 @@
+#!/bash
+
+set -o errexit
+set -o nounset
+
+# pull images unless they already exist
+for i in docker.io/library/nginx \
+	 docker.io/traefik/whoami
+do
+    if ! podman image exists $i
+    then podman pull $i
+    fi
+done
+
+mkdir -p ~/.config/containers/systemd
+mkdir -p ~/.config/systemd/user
+
+cp nginx.socket ~/.config/systemd/user
+cp nginx.container ~/.config/containers/systemd
+cp whoami1.container ~/.config/containers/systemd
+cp whoami2.container ~/.config/containers/systemd
+cp example7.network ~/.config/containers/systemd
+
+openssl genrsa -out ~/ca.key 4096
+openssl req -x509 -new -nodes -key ~/ca.key -sha256 -days 365 -out ~/ca.crt -subj "/CN=root ca"
+openssl genrsa -out ~/server.key 2048
+openssl req -new -key ~/server.key -out ~/server.csr  -batch -addext "subjectAltName=DNS:whoami1.example.com,DNS:whoami2.example.com"
+openssl x509 -req -in ~/server.csr -CA ~/ca.crt -CAkey ~/ca.key -CAcreateserial -out ~/server.crt -days 365 -sha256 -copy_extensions copy
+
+systemctl --user daemon-reload
+systemctl --user start whoami1.service
+systemctl --user start whoami2.service
+systemctl --user start nginx.socket
+systemctl --user start nginx.service

--- a/examples/example7/nginx-reverse-proxy-conf/default.conf
+++ b/examples/example7/nginx-reverse-proxy-conf/default.conf
@@ -1,0 +1,10 @@
+server {
+  listen 80 default_server;
+  listen [::]:80 default_server;
+  listen 443 ssl default_server;
+  listen [::]:443 ssl default_server;
+  server_name _;
+  ssl_certificate /etc/ssl/certs/server.crt;
+  ssl_certificate_key /etc/ssl/private/server.key;
+  return 404;
+}

--- a/examples/example7/nginx-reverse-proxy-conf/whoami1-example-com.conf
+++ b/examples/example7/nginx-reverse-proxy-conf/whoami1-example-com.conf
@@ -1,0 +1,23 @@
+server {
+  listen 80;
+  listen [::]:80;
+  server_name whoami1.example.com;
+  return 301 https://$host$request_uri;
+}
+
+server {
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  server_name whoami1.example.com;
+  ssl_certificate /etc/ssl/certs/server.crt;
+  ssl_certificate_key /etc/ssl/private/server.key;
+
+  location / {
+    proxy_pass http://whoami1:80;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto  $scheme;    
+    proxy_redirect off;
+  }
+}

--- a/examples/example7/nginx-reverse-proxy-conf/whoami2-example-com.conf
+++ b/examples/example7/nginx-reverse-proxy-conf/whoami2-example-com.conf
@@ -1,0 +1,23 @@
+server {
+  listen 80;
+  listen [::]:80;
+  server_name whoami2.example.com;
+  return 301 https://$host$request_uri;
+}
+
+server {
+  listen 443 ssl;
+  listen [::]:443 ssl;
+  server_name whoami2.example.com;
+  ssl_certificate /etc/ssl/certs/server.crt;
+  ssl_certificate_key /etc/ssl/private/server.key;
+
+  location / {
+    proxy_pass http://whoami2:80;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto  $scheme;    
+    proxy_redirect off;
+  }
+}

--- a/examples/example7/nginx.container
+++ b/examples/example7/nginx.container
@@ -1,0 +1,15 @@
+[Unit]
+After=nginx.socket
+Requires=nginx.socket
+
+[Container]
+ContainerName=nginx
+Environment=NGINX=3:4;
+Image=docker.io/library/nginx
+Network=example7.network
+Volume=%h/podman-nginx-socket-activation/examples/example7/nginx-reverse-proxy-conf/whoami1-example-com.conf:/etc/nginx/conf.d/whoami-1example-com.conf:Z
+Volume=%h/podman-nginx-socket-activation/examples/example7/nginx-reverse-proxy-conf/whoami2-example-com.conf:/etc/nginx/conf.d/whoami2-example-com.conf:Z
+Volume=%h/podman-nginx-socket-activation/examples/example7/nginx-reverse-proxy-conf/default.conf:/etc/nginx/conf.d/default.conf:Z
+Volume=%h/server.key:/etc/ssl/private/server.key:Z
+Volume=%h/server.crt:/etc/ssl/certs/server.crt:Z
+

--- a/examples/example7/nginx.socket
+++ b/examples/example7/nginx.socket
@@ -1,0 +1,9 @@
+[Unit]
+Description=nginx sockets
+
+[Socket]
+ListenStream=80
+ListenStream=443
+
+[Install]
+WantedBy=sockets.target

--- a/examples/example7/whoami1.container
+++ b/examples/example7/whoami1.container
@@ -1,0 +1,4 @@
+[Container]
+Image=docker.io/traefik/whoami
+ContainerName=whoami1
+Network=example7.network

--- a/examples/example7/whoami2.container
+++ b/examples/example7/whoami2.container
@@ -1,0 +1,4 @@
+[Container]
+Image=docker.io/traefik/whoami
+ContainerName=whoami2
+Network=example7.network


### PR DESCRIPTION

This example shows an HTTP reverse proxy for two backend web server containers (whoami1 and whoami2).
All containers are run by rootless podman with quadlets. A self sigend certificate created with `openssl` is used to provide https. Status: beta

The example does not use the systemd directive `User=`. The podman project does not support the use of systemd directive `User=`.  As there are no experimental podman features in use in this example, I think the example can be given the status `beta`.