### PR TITLE
Add `Options=isolate=true` to network quadlets

### DIFF
--- a/examples/example4/example4-net.network
+++ b/examples/example4/example4-net.network
@@ -1,3 +1,4 @@
 [Network]
+Options=isolate=true
 # To give the containers access to the internet, remove the line `Internal=true`
 Internal=true

--- a/examples/example7/example7.network
+++ b/examples/example7/example7.network
@@ -1,3 +1,4 @@
 [Network]
+Options=isolate=true
 # To give the containers access to the internet, remove the line `Internal=true`
 Internal=true


### PR DESCRIPTION
Add `Options=isolate=true` to network quadlets.

Containers in different custom networks can't connect to each other if the networks were created
with `--opt=isolate=strict`

Here is an example:

#### without --opt=isolate=strict
```
$ podman network create mynet1
$ podman network create mynet2
$ podman run --rm --name ngi --network mynet1 -d docker.io/library/nginx
$ podman container inspect ngi | jq -r '.[0].NetworkSettings.Networks.mynet1.IPAddress'
10.89.10.2
$ podman run --rm --network mynet2 docker.io/library/fedora curl --connect-timeout 3 -sS 10.89.10.2 | head -4
<!DOCTYPE html>
<html>
<head>
<title>Welcome to nginx!</title>
```

#### with `--opt=isolate=strict`

```
$ podman network create --opt=isolate=strict mynet1
$ podman network create --opt=isolate=strict mynet2
$ podman run --rm --name ngi --network mynet1 -d docker.io/library/nginx
$ podman container inspect ngi | jq -r '.[0].NetworkSettings.Networks.mynet1.IPAddress'
10.89.12.2
$ podman run --rm --network mynet2 docker.io/library/fedora curl --connect-timeout 3 -sS 10.89.12.2
curl: (28) Connection timed out after 3001 milliseconds
```
