### PR TITLE
remove sudo from install.bash

### DIFF
--- a/examples/example4/install.bash
+++ b/examples/example4/install.bash
@@ -3,36 +3,42 @@
 set -o errexit
 set -o nounset
 
+# This script should be executed as root.
+
 repodir=$1
 user=$2
 
 # Alternatively a system account with no shell access could be created:
-# sudo useradd --system --shell /usr/sbin/nologin --create-home --add-subids-for-system -d "/home/$user" -- "$user"
-sudo useradd -- "$user"
+# useradd --system --shell /usr/sbin/nologin --create-home --add-subids-for-system -d "/home/$user" -- "$user"
+useradd -- "$user"
 
 uid=$(id -u -- "$user")
+
 sourcedir="$repodir/examples/example4"
 
-sudo install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/nginx-reverse-proxy-conf"
-sudo install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/nginx-reverse-proxy-conf" "$sourcedir/nginx-reverse-proxy-conf/apache-example-com.conf"
-sudo install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/nginx-reverse-proxy-conf" "$sourcedir/nginx-reverse-proxy-conf/caddy-example-com.conf"
-sudo install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/nginx-reverse-proxy-conf" "$sourcedir/nginx-reverse-proxy-conf/default.conf"
+install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/nginx-reverse-proxy-conf"
+install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/nginx-reverse-proxy-conf" "$sourcedir/nginx-reverse-proxy-conf/apache-example-com.conf"
+install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/nginx-reverse-proxy-conf" "$sourcedir/nginx-reverse-proxy-conf/caddy-example-com.conf"
+install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/nginx-reverse-proxy-conf" "$sourcedir/nginx-reverse-proxy-conf/default.conf"
 
-sudo install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/.config"
-sudo install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/.config/containers"
-sudo install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/.config/containers/systemd"
-sudo install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/.config/containers/systemd" "$sourcedir/apache.container"
-sudo install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/.config/containers/systemd" "$sourcedir/caddy.container"
-sudo install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/.config/containers/systemd" "$sourcedir/example4-net.network"
-sudo install --mode 0644 -Z -D -o root -g root --target-directory /etc/systemd/system/ "$sourcedir/example4.socket"
+install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/.config"
+install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/.config/containers"
+install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/.config/containers/systemd"
+install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/.config/containers/systemd" "$sourcedir/apache.container"
+install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/.config/containers/systemd" "$sourcedir/caddy.container"
+install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/.config/containers/systemd" "$sourcedir/example4-net.network"
+install --mode 0644 -Z -D -o root -g root --target-directory /etc/systemd/system/ "$sourcedir/example4.socket"
 
 # envsubst is used for text replacement in example4.service
-cat $repodir/examples/example4/example4.service.in | sudo bash -c "cat - | envsubst_user=$user envsubst_uid=$uid envsubst > /etc/systemd/system/example4.service"
 
-sudo loginctl enable-linger "$user"
+"$sourcedir/nginx.container" /etc/containers/systemd/nginx.container
 
-sudo systemctl daemon-reload
-sudo systemctl --user -M "$user@" daemon-reload
-sudo systemctl --user -M "$user@" start apache.service
-sudo systemctl --user -M "$user@" start caddy.service
-sudo systemctl start example4.socket
+cat $repodir/examples/example4/nginx.container | envsubst_user=$user envsubst_uid=$uid envsubst > /etc/container/system/example4.container
+
+loginctl enable-linger "$user"
+
+systemctl daemon-reload
+systemctl --user -M "$user@" daemon-reload
+systemctl --user -M "$user@" start apache.service
+systemctl --user -M "$user@" start caddy.service
+systemctl start example4.socket

--- a/examples/example5/install.bash
+++ b/examples/example5/install.bash
@@ -3,33 +3,35 @@
 set -o errexit
 set -o nounset
 
+# This script should be executed as root.
+
 repodir=$1
 user=$2
 
 # Alternatively a system account with no shell access could be created:
-# sudo useradd --system --shell /usr/sbin/nologin --create-home --add-subids-for-system -d "/home/$user" -- "$user"
-sudo useradd -- "$user"
+# useradd --system --shell /usr/sbin/nologin --create-home --add-subids-for-system -d "/home/$user" -- "$user"
+useradd -- "$user"
 
 uid=$(id -u -- "$user")
 sourcedir="$repodir/examples/example5"
 
-sudo install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/nginx-reverse-proxy-conf"
-sudo install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/nginx-reverse-proxy-conf" "$sourcedir/nginx-reverse-proxy-conf/caddy-example-com.conf"
-sudo install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/nginx-reverse-proxy-conf" "$sourcedir/nginx-reverse-proxy-conf/default.conf"
+install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/nginx-reverse-proxy-conf"
+install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/nginx-reverse-proxy-conf" "$sourcedir/nginx-reverse-proxy-conf/caddy-example-com.conf"
+install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/nginx-reverse-proxy-conf" "$sourcedir/nginx-reverse-proxy-conf/default.conf"
 
-sudo install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/socketdir"
-sudo install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user" "$sourcedir/Caddyfile"
+install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/socketdir"
+install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user" "$sourcedir/Caddyfile"
 
-sudo install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/.config/containers/systemd"
-sudo install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/.config/containers/systemd" "$sourcedir/caddy.container"
-sudo install --mode 0644 -Z -D -o root -g root --target-directory /etc/systemd/system/ "$sourcedir/example5.socket"
+install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/.config/containers/systemd"
+install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/.config/containers/systemd" "$sourcedir/caddy.container"
+install --mode 0644 -Z -D -o root -g root --target-directory /etc/systemd/system/ "$sourcedir/example5.socket"
 
 # envsubst is used for text replacement in example5.service
-cat $repodir/examples/example5/example5.service.in | sudo bash -c "cat - | envsubst_user=$user envsubst_uid=$uid envsubst > /etc/systemd/system/example5.service"
+cat $repodir/examples/example5/example5.service.in | envsubst_user=$user envsubst_uid=$uid envsubst > /etc/systemd/system/example5.service
 
-sudo loginctl enable-linger $user
+loginctl enable-linger $user
 
-sudo systemctl daemon-reload
-sudo systemctl --user -M "$user@" daemon-reload
-sudo systemctl --user -M "$user@" start caddy.service
-sudo systemctl start example5.socket
+systemctl daemon-reload
+systemctl --user -M "$user@" daemon-reload
+systemctl --user -M "$user@" start caddy.service
+systemctl start example5.socket

--- a/examples/example6/install.bash
+++ b/examples/example6/install.bash
@@ -3,43 +3,45 @@
 set -o errexit
 set -o nounset
 
+# This script should be executed as root.
+
 repodir=$1
 user=$2
 
 # Alternatively a system account with no shell access could be created:
-# sudo useradd --system --shell /usr/sbin/nologin --create-home --add-subids-for-system -d "/home/$user" -- "$user"
-sudo useradd -- "$user"
+# useradd --system --shell /usr/sbin/nologin --create-home --add-subids-for-system -d "/home/$user" -- "$user"
+useradd -- "$user"
 
-sudo mkdir -p /srv/backend-socketdir
+mkdir -p /srv/backend-socketdir
 
-#sudo chown  -- "$user:$user" /srv/dir
+#chown  -- "$user:$user" /srv/dir
 
 uid=$(id -u -- "$user")
 
 sourcedir="$repodir/examples/example6"
 
-sudo install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/nginx-reverse-proxy-conf"
-sudo install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/nginx-reverse-proxy-conf" "$sourcedir/nginx-reverse-proxy-conf/nginx-example-com.conf"
-sudo install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/nginx-reverse-proxy-conf" "$sourcedir/nginx-reverse-proxy-conf/default.conf"
+install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/nginx-reverse-proxy-conf"
+install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/nginx-reverse-proxy-conf" "$sourcedir/nginx-reverse-proxy-conf/nginx-example-com.conf"
+install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/nginx-reverse-proxy-conf" "$sourcedir/nginx-reverse-proxy-conf/default.conf"
 
-sudo install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/nginx-backend-conf"
-sudo install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/nginx-backend-conf" "$sourcedir/nginx-backend-conf/default.conf"
+install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/nginx-backend-conf"
+install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/nginx-backend-conf" "$sourcedir/nginx-backend-conf/default.conf"
 
-sudo install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/.config/containers/systemd"
-sudo install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/.config/containers/systemd" "$sourcedir/nginx.container"
-sudo install --mode 0644 -Z -D -o root -g root --target-directory /etc/systemd/system/ "$sourcedir/example6-proxy.socket"
+install --mode 0755 -Z -d -o "$user" -g "$user" "/home/$user/.config/containers/systemd"
+install --mode 0644 -Z -D -o "$user" -g "$user" --target-directory "/home/$user/.config/containers/systemd" "$sourcedir/nginx.container"
+install --mode 0644 -Z -D -o root -g root --target-directory /etc/systemd/system/ "$sourcedir/example6-proxy.socket"
 
 # envsubst is used for text replacement
-cat $repodir/examples/example6/example6-proxy.service.in | sudo bash -c "cat - | envsubst_user=$user envsubst_uid=$uid envsubst > /etc/systemd/system/example6-proxy.service"
-cat $repodir/examples/example6/example6-backend.service.in | sudo bash -c "cat - | envsubst_user=$user envsubst_uid=$uid envsubst > /etc/systemd/system/example6-backend.service"
-cat $repodir/examples/example6/example6-backend.socket.in | sudo bash -c "cat - | envsubst_user=$user envsubst_uid=$uid envsubst > /etc/systemd/system/example6-backend.socket"
-cat $repodir/examples/example6/nginx-backend-conf/nginx-example-com.conf.in | sudo bash -c "cat - | envsubst_user=$user envsubst_uid=$uid envsubst > /home/$user/nginx-backend-conf/nginx-example-com.conf"
+cat $repodir/examples/example6/example6-proxy.service.in | envsubst_user=$user envsubst_uid=$uid envsubst > /etc/systemd/system/example6-proxy.service
+cat $repodir/examples/example6/example6-backend.service.in | envsubst_user=$user envsubst_uid=$uid envsubst > /etc/systemd/system/example6-backend.service
+cat $repodir/examples/example6/example6-backend.socket.in | envsubst_user=$user envsubst_uid=$uid envsubst > /etc/systemd/system/example6-backend.socket
+cat $repodir/examples/example6/nginx-backend-conf/nginx-example-com.conf.in | envsubst_user=$user envsubst_uid=$uid envsubst > /home/$user/nginx-backend-conf/nginx-example-com.conf
 
-sudo chown "$user:$user" "/home/$user/nginx-backend-conf/nginx-example-com.conf"
+chown "$user:$user" "/home/$user/nginx-backend-conf/nginx-example-com.conf"
 
-sudo loginctl enable-linger "$user"
+loginctl enable-linger "$user"
 
-sudo systemctl daemon-reload
+systemctl daemon-reload
 
-sudo systemctl start example6-backend.socket
-sudo systemctl start example6-proxy.socket
+systemctl start example6-backend.socket
+systemctl start example6-proxy.socket


### PR DESCRIPTION
sudo is not always present on a modern systems.
Nowadays run0 is prefered because it is a more secure alternative.
Remove sudo from install.bash so that it is possible to execute install.bash with run0.